### PR TITLE
Fix HTTPGateway, reset Hasura on configuration failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ cython_debug/
 .noseids
 
 secrets.env
+
+*.out*

--- a/src/dipdup/cli.py
+++ b/src/dipdup/cli.py
@@ -160,6 +160,7 @@ async def migrate(ctx):
         raise ConfigurationError('Unknown `spec_version`')
 
 
+# TODO: "cache clear"?
 @cli.command(help='Clear development request cache')
 @click.pass_context
 @cli_wrapper
@@ -167,14 +168,14 @@ async def clear_cache(ctx):
     FileCache('dipdup', flag='cs').clear()
 
 
-@cli.group()
+@cli.group(help='Docker integration related commands')
 @click.pass_context
 @cli_wrapper
 async def docker(ctx):
     ...
 
 
-@docker.command(name='init')
+@docker.command(name='init', help='Generate Docker inventory in project directory')
 @click.option('--image', '-i', type=str, help='DipDup Docker image', default=DEFAULT_DOCKER_IMAGE)
 @click.option('--tag', '-t', type=str, help='DipDup Docker tag', default=DEFAULT_DOCKER_TAG)
 @click.option('--env-file', '-e', type=str, help='Path to env_file', default=DEFAULT_DOCKER_ENV_FILE)
@@ -185,7 +186,7 @@ async def docker_init(ctx, image: str, tag: str, env_file: str):
     await DipDupCodeGenerator(config, {}).generate_docker(image, tag, env_file)
 
 
-@cli.group()
+@cli.group(help='Hasura integration related commands')
 @click.pass_context
 @cli_wrapper
 async def hasura(ctx):

--- a/src/dipdup/cli.py
+++ b/src/dipdup/cli.py
@@ -202,10 +202,15 @@ async def hasura_configure(ctx, reset: bool):
     url = config.database.connection_string
     models = f'{config.package}.models'
     if not config.hasura:
-        _logger.error('`hasura` config section is empty')
-        return
-    hasura_gateway = HasuraGateway(config.package, config.hasura, cast(PostgresDatabaseConfig, config.database))
+        raise ConfigurationError('`hasura` config section is empty')
+    if reset:
+        config.hasura.reset = True
+    hasura_gateway = HasuraGateway(
+        package=config.package,
+        hasura_config=config.hasura,
+        database_config=cast(PostgresDatabaseConfig, config.database),
+    )
 
     async with tortoise_wrapper(url, models):
         async with hasura_gateway:
-            await hasura_gateway.configure(reset)
+            await hasura_gateway.configure()

--- a/src/dipdup/config.py
+++ b/src/dipdup/config.py
@@ -659,6 +659,7 @@ class HasuraConfig:
     camel_case: bool = False
     connection_timeout: int = 5
     rest: bool = True
+    reset: Optional[bool] = None
     http: Optional[HTTPConfig] = None
 
     @validator('url', allow_reuse=True)

--- a/src/dipdup/config.py
+++ b/src/dipdup/config.py
@@ -7,6 +7,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from copy import copy
 from enum import Enum
 from os import environ as env
 from os.path import dirname
@@ -101,12 +102,13 @@ class HTTPConfig:
     connection_limit: Optional[int] = None
     batch_size: Optional[int] = None
 
-    def merge(self, other: Optional['HTTPConfig']) -> None:
-        if not other:
-            return
-        for k, v in other.__dict__.items():
-            if v is not None:
-                setattr(self, k, v)
+    def merge(self, other: Optional['HTTPConfig']) -> 'HTTPConfig':
+        config = copy(self)
+        if other:
+            for k, v in other.__dict__.items():
+                if v is not None:
+                    setattr(config, k, v)
+        return config
 
 
 @dataclass

--- a/src/dipdup/datasources/bcd/datasource.py
+++ b/src/dipdup/datasources/bcd/datasource.py
@@ -8,13 +8,22 @@ TOKENS_REQUEST_LIMIT = 10
 
 
 class BcdDatasource(Datasource):
+    _default_http_config = HTTPConfig(
+        cache=True,
+        retry_sleep=1,
+        retry_multiplier=1.1,
+        ratelimit_rate=100,
+        ratelimit_period=30,
+        connection_limit=25,
+    )
+
     def __init__(
         self,
         url: str,
         network: str,
         http_config: Optional[HTTPConfig] = None,
     ) -> None:
-        super().__init__(url, http_config)
+        super().__init__(url, self._default_http_config.merge(http_config))
         self._logger = logging.getLogger('dipdup.bcd')
         self._network = network
 
@@ -45,13 +54,3 @@ class BcdDatasource(Datasource):
         if response:
             return response[0]
         return None
-
-    def _default_http_config(self) -> HTTPConfig:
-        return HTTPConfig(
-            cache=True,
-            retry_sleep=1,
-            retry_multiplier=1.1,
-            ratelimit_rate=100,
-            ratelimit_period=30,
-            connection_limit=25,
-        )

--- a/src/dipdup/datasources/datasource.py
+++ b/src/dipdup/datasources/datasource.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from enum import Enum
 from logging import Logger
-from typing import Awaitable, List, Optional, Protocol
+from typing import Awaitable, List, Protocol
 
 from pyee import AsyncIOEventEmitter  # type: ignore
 
@@ -46,7 +46,7 @@ class Datasource(HTTPGateway):
 
 
 class IndexDatasource(Datasource, AsyncIOEventEmitter):
-    def __init__(self, url: str, http_config: Optional[HTTPConfig] = None) -> None:
+    def __init__(self, url: str, http_config: HTTPConfig) -> None:
         HTTPGateway.__init__(self, url, http_config)
         AsyncIOEventEmitter.__init__(self)
 

--- a/src/dipdup/datasources/tzkt/datasource.py
+++ b/src/dipdup/datasources/tzkt/datasource.py
@@ -288,12 +288,21 @@ class TzktDatasource(IndexDatasource):
     * Calls Matchers to match received operation groups with indexes' pattern and spawn callbacks on match
     """
 
+    _default_http_config = HTTPConfig(
+        cache=True,
+        retry_sleep=1,
+        retry_multiplier=1.1,
+        ratelimit_rate=100,
+        ratelimit_period=30,
+        connection_limit=25,
+    )
+
     def __init__(
         self,
         url: str,
         http_config: Optional[HTTPConfig] = None,
     ) -> None:
-        super().__init__(url, http_config)
+        super().__init__(url, self._default_http_config.merge(http_config))
         self._logger = logging.getLogger('dipdup.tzkt')
 
         self._transaction_subscriptions: Set[str] = set()
@@ -621,16 +630,6 @@ class TzktDatasource(IndexDatasource):
         await self._send(
             'SubscribeToHead',
             [],
-        )
-
-    def _default_http_config(self) -> HTTPConfig:
-        return HTTPConfig(
-            cache=True,
-            retry_sleep=1,
-            retry_multiplier=1.1,
-            ratelimit_rate=100,
-            ratelimit_period=30,
-            connection_limit=25,
         )
 
     async def _extract_message_data(self, channel: str, message: List[Any]) -> Any:

--- a/src/dipdup/datasources/tzkt/datasource.py
+++ b/src/dipdup/datasources/tzkt/datasource.py
@@ -637,7 +637,7 @@ class TzktDatasource(IndexDatasource):
         for item in message:
             head_level = item['state']
             message_type = TzktMessageType(item['type'])
-            self._logger.debug('`%s` message: %s', channel, message_type.name) 
+            self._logger.debug('`%s` message: %s', channel, message_type.name)
 
             if message_type == TzktMessageType.STATE:
                 if self._sync_level != head_level:
@@ -656,7 +656,6 @@ class TzktDatasource(IndexDatasource):
 
             else:
                 raise NotImplementedError
-
 
     async def _on_operation_message(self, message: List[Dict[str, Any]]) -> None:
         """Parse and emit raw operations from WS"""

--- a/src/dipdup/hasura.py
+++ b/src/dipdup/hasura.py
@@ -135,10 +135,8 @@ class HasuraGateway(HTTPGateway):
     def _default_http_config(self) -> HTTPConfig:
         return HTTPConfig(
             cache=False,
+            retry_count=3,
             retry_sleep=1,
-            retry_multiplier=1.1,
-            ratelimit_rate=100,
-            ratelimit_period=1,
         )
 
     async def _hasura_request(self, endpoint: str, json: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/dipdup/hasura.py
+++ b/src/dipdup/hasura.py
@@ -192,7 +192,6 @@ class HasuraGateway(HTTPGateway):
             "args": metadata,
         }
         try:
-            self._logger.info(self._http_config)
             await self._hasura_request(endpoint, json)
         except aiohttp.ClientResponseError as e:
             # NOTE: 400 from Hasura means we failed either to generate or to merge existing metadata.

--- a/src/dipdup/index.py
+++ b/src/dipdup/index.py
@@ -1,7 +1,7 @@
+import time
 from abc import abstractmethod
 from collections import defaultdict, deque, namedtuple
-from contextlib import asynccontextmanager, suppress
-import time
+from contextlib import suppress
 from typing import Deque, Dict, List, Optional, Set, Tuple, Union, cast
 
 from pydantic.error_wrappers import ValidationError

--- a/src/dipdup/index.py
+++ b/src/dipdup/index.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from collections import defaultdict, deque, namedtuple
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
+import time
 from typing import Deque, Dict, List, Optional, Set, Tuple, Union, cast
 
 from pydantic.error_wrappers import ValidationError
@@ -309,14 +310,12 @@ class OperationIndex(Index):
                         operation_idx += 1
 
                     if pattern_idx == len(handler_config.pattern):
-                        self._logger.info('%s: `%s` handler matched!', operation_subgroup.hash, handler_config.callback)
                         await self._on_match(operation_subgroup, handler_config, matched_operations)
 
                         matched_operations = []
                         pattern_idx = 0
 
                 if len(matched_operations) >= sum(map(lambda x: 0 if x.optional else 1, handler_config.pattern)):
-                    self._logger.info('%s: `%s` handler matched!', operation_subgroup.hash, handler_config.callback)
                     await self._on_match(operation_subgroup, handler_config, matched_operations)
 
     async def _on_match(
@@ -326,6 +325,9 @@ class OperationIndex(Index):
         matched_operations: List[Optional[OperationData]],
     ):
         """Prepare handler arguments, parse parameter and storage. Schedule callback in executor."""
+        self._logger.info('%s: `%s` handler matched!', operation_subgroup.hash, handler_config.callback)
+        start = time.perf_counter()
+
         args: List[Optional[Union[Transaction, Origination, OperationData]]] = []
         for pattern_config, operation in zip(handler_config.pattern, matched_operations):
             if operation is None:
@@ -384,6 +386,9 @@ class OperationIndex(Index):
         )
 
         await handler_config.callback_fn(handler_context, *args)
+
+        end = time.perf_counter()
+        self._logger.debug(f'{handler_config.callback}` handler executed in {end - start:.3f}s')
 
         if handler_context.updated:
             self._ctx.commit()
@@ -491,6 +496,8 @@ class BigMapIndex(Index):
         matched_big_map: BigMapData,
     ) -> None:
         """Prepare handler arguments, parse key and value. Schedule callback in executor."""
+        self._logger.info('%s: `%s` handler matched!', matched_big_map.operation_id, handler_config.callback)
+        start = time.perf_counter()
 
         if matched_big_map.action.has_key:
             key_type = handler_config.key_type_cls
@@ -532,6 +539,9 @@ class BigMapIndex(Index):
 
         await handler_config.callback_fn(handler_context, big_map_context)
 
+        end = time.perf_counter()
+        self._logger.debug(f'{handler_config.callback}` handler executed in {end - start:.3f}s')
+
         if handler_context.updated:
             self._ctx.commit()
 
@@ -542,7 +552,6 @@ class BigMapIndex(Index):
             for handler_config in self._config.handlers:
                 big_map_matched = await self._match_big_map(handler_config, big_map)
                 if big_map_matched:
-                    self._logger.info('%s: `%s` handler matched!', big_map.operation_id, handler_config.callback)
                     await self._on_match(handler_config, big_map)
 
     async def _get_big_map_addresses(self) -> Set[str]:


### PR DESCRIPTION
Improvements:
* Add `reset` option to `HasuraConfig`. Reset on failure only by default. 
* Help messages for CLI commands.
* Log time of handler callback execution.

`HTTPGateway` bugfixes:
* Fix merging user config
* Fix infinite retry loop
* Fix ratelimit not being applied between attempts