### PR TITLE
Solve functions not found in operation handlers with subpackages

### DIFF
--- a/src/dipdup/config.py
+++ b/src/dipdup/config.py
@@ -609,7 +609,7 @@ class CallbackMixin(CodegenMixin):
             return
         _logger.debug('Registering %s callback `%s`', self.kind, self.callback)
         module_name = f'{package}.{self.kind}s.{self.callback}'
-        fn_name = self.callback
+        fn_name = self.callback.rsplit('.', 1)[-1]
         self.callback_fn = import_from(module_name, fn_name)
 
 


### PR DESCRIPTION
Operation handlers didn't account for subpackage names in callback name