### PR TITLE
Fix "invalid value `environment`" Sentry error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+### Fixed
+
+- sentry: Fixed "invalid value `environment`" error.
+
 ## [6.0.0] - 2022-08-08
 
 This release contains no changes except for the version number.

--- a/src/dipdup/cli.py
+++ b/src/dipdup/cli.py
@@ -147,15 +147,19 @@ def _init_sentry(config: DipDupConfig) -> None:
             event_level=event_level,
         ),
     ]
-    sentry_sdk.init(
-        dsn=config.sentry.dsn,
-        environment=config.sentry.environment,
-        server_name=config.sentry.server_name,
-        release=config.sentry.release or __version__,
-        integrations=integrations,
-        attach_stacktrace=attach_stacktrace,
-        before_send=_sentry_before_send,
-    )
+    init_kwargs: Dict[str, Any] = {
+        'dsn': config.sentry.dsn,
+        'integrations': integrations,
+        'attach_stacktrace': attach_stacktrace,
+        'before_send': _sentry_before_send,
+        'release': config.sentry.release or __version__,
+    }
+    if config.sentry.environment:
+        init_kwargs['environment'] = config.sentry.environment
+    if config.sentry.server_name:
+        init_kwargs['server_name'] = config.sentry.server_name
+
+    sentry_sdk.init(**init_kwargs)
     sentry_sdk.set_tag('dipdup_version', __version__)
     sentry_sdk.set_tag('dipdup_package', config.package)
 


### PR DESCRIPTION
Closes #455 