### PR TITLE
Improve config validation and help messages

### DIFF
--- a/src/dipdup/config.py
+++ b/src/dipdup/config.py
@@ -1230,6 +1230,7 @@ class DipDupConfig:
         self.paths: List[str] = []
         self.environment: Dict[str, str] = {}
         self._callback_patterns: Dict[str, List[Sequence[HandlerPatternConfigT]]] = defaultdict(list)
+        self._contract_addresses = {contract.address for contract in self.contracts.values()}
 
     @cached_property
     def schema_name(self) -> str:

--- a/src/dipdup/context.py
+++ b/src/dipdup/context.py
@@ -228,7 +228,11 @@ class DipDupContext:
         """
         self.logger.info('Creating contract `%s` with typename `%s`', name, typename)
         if name in self.config.contracts:
+            raise ContractAlreadyExistsError(self, name)
+        if address in self.config._contract_addresses:
             raise ContractAlreadyExistsError(self, name, address)
+        else:
+            self.config._contract_addresses.add(address)
 
         contract_config = ContractConfig(
             address=address,

--- a/src/dipdup/context.py
+++ b/src/dipdup/context.py
@@ -227,8 +227,8 @@ class DipDupContext:
         :param typename: Alias for the contract script
         """
         self.logger.info('Creating contract `%s` with typename `%s`', name, typename)
-        if name in self.config.contracts:
-            raise ContractAlreadyExistsError(self, name)
+        if contract := self.config.contracts.get(name):
+            raise ContractAlreadyExistsError(self, name, contract.address)
         if address in self.config._contract_addresses:
             raise ContractAlreadyExistsError(self, name, address)
         else:

--- a/src/dipdup/exceptions.py
+++ b/src/dipdup/exceptions.py
@@ -240,8 +240,8 @@ class ContractAlreadyExistsError(DipDupError):
     """Attempt to add a contract with alias or address already in use"""
 
     ctx: Any
-    name: Optional[str] = None
-    address: Optional[str] = None
+    name: str
+    address: str
 
     def _help(self) -> str:
         contracts_table = indent(
@@ -250,9 +250,9 @@ class ContractAlreadyExistsError(DipDupError):
                 tablefmt='plain',
             )
         )
-        what = f'name `{self.name}`' if self.name else f'address `{self.address}`'
+        what = f'name `{self.name}`' if self.name else f'address'
         return f"""
-            Contract with {what} already exists.
+            Contract `{self.name}` (`{self.address}`) already exists.
 
             Active contracts:
 

--- a/src/dipdup/exceptions.py
+++ b/src/dipdup/exceptions.py
@@ -250,7 +250,6 @@ class ContractAlreadyExistsError(DipDupError):
                 tablefmt='plain',
             )
         )
-        what = f'name `{self.name}`' if self.name else f'address'
         return f"""
             Contract `{self.name}` (`{self.address}`) already exists.
 

--- a/src/dipdup/exceptions.py
+++ b/src/dipdup/exceptions.py
@@ -118,19 +118,22 @@ class ConfigurationError(DipDupError):
 
 @dataclass(repr=False)
 class DatabaseConfigurationError(ConfigurationError):
-    """DipDup can't initialize database with given models and parameters"""
+    """Can't initialize database, `models.py` module is invalid"""
 
     model: Type[Model]
+    field: Optional[str] = None
 
     def _help(self) -> str:
         return f"""
             {self.msg}
 
-            Model: `{self.model._meta._model.__name__}`
-            Table: `{self.model._meta.db_table}`
+              model: `{self.model._meta._model.__name__}`
+              table: `{self.model._meta.db_table}`
+              field: `{self.field or ''}`
 
-            Tortoise ORM examples: https://tortoise-orm.readthedocs.io/en/latest/examples.html
-            DipDup config reference: https://dipdup.net/docs/config/database
+            See https://dipdup.net/docs/getting-started/defining-models
+            See https://dipdup.net/docs/config/database
+            See https://dipdup.net/docs/advanced/internal-models
         """
 
 
@@ -219,9 +222,9 @@ class ProjectImportError(DipDupError):
     obj: Optional[str] = None
 
     def _help(self) -> str:
-        what = f'`{self.obj}` from' if self.obj else ''
+        what = f'`{self.obj}` from ' if self.obj else ''
         return f"""
-            Failed to import {what} module `{self.module}`.
+            Failed to import {what}module `{self.module}`.
 
             Reasons in order of possibility:
 
@@ -237,8 +240,8 @@ class ContractAlreadyExistsError(DipDupError):
     """Attempt to add a contract with alias or address already in use"""
 
     ctx: Any
-    name: str
-    address: str
+    name: Optional[str] = None
+    address: Optional[str] = None
 
     def _help(self) -> str:
         contracts_table = indent(
@@ -247,8 +250,9 @@ class ContractAlreadyExistsError(DipDupError):
                 tablefmt='plain',
             )
         )
+        what = f'name `{self.name}`' if self.name else f'address `{self.address}`'
         return f"""
-            Contract with name `{self.name}` or address `{self.address}` already exists.
+            Contract with {what} already exists.
 
             Active contracts:
 
@@ -340,6 +344,9 @@ class CallbackTypeError(DipDupError):
               expected type: {self.expected_type}
 
             Make sure to set correct typenames in config and run `dipdup init --overwrite-types` to regenerate typeclasses.
+
+            See https://dipdup.net/docs/getting-started/project-structure
+            See https://dipdup.net/docs/cli-reference#init
         """
 
 
@@ -355,7 +362,9 @@ class HasuraError(DipDupError):
 
               {self.msg}
 
-            Check out Hasura logs for more information.
+            If it's `400 Bad Request`, check out Hasura logs for more information.
 
-            GraphQL integration docs: https://dipdup.net/docs/graphql/
+            See https://dipdup.net/docs/graphql/
+            See https://dipdup.net/docs/config/hasura.html
+            See https://dipdup.net/docs/cli-reference.html#dipdup-hasura-configure
         """

--- a/src/dipdup/utils/database.py
+++ b/src/dipdup/utils/database.py
@@ -234,7 +234,7 @@ def prepare_models(package: Optional[str]) -> None:
             db_tables.add(model._meta.db_table)
         else:
             raise DatabaseConfigurationError(
-                'Duplicate table name detected. Make sure that all models have unique table names.',
+                'Table name is duplicated or reserved. Make sure that all models have unique table names.',
                 model,
             )
 


### PR DESCRIPTION
* Check addresses for `ContractAlreadyExistsError`
* Print field name in `DatabaseConfigurationError` if applicable
* Check for duplicate and reserved table names
* More info and links in help messages